### PR TITLE
Add Vercel rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Because this is a single-page app, loading the page on any route besides `/` causes a 404 error when deployed on Vercel. This resolves this issue by implementing Vercel rewrites for all non-root routes.